### PR TITLE
Add header union information for extract operator

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5894,7 +5894,7 @@ pseudo-code method, using data from the `packet` class defined
 above. We use the special `valid$` identifier to indicate the
 hidden valid bit of a header, `isNext$` to indicate that the
 l-value was obtained using `next`, and `nextIndex$` to
-indicate the corresponding header stack properties.
+indicate the corresponding header or header union stack properties.
 
 ~ Begin P4Pseudo
 void packet_in.extract<T>(out T headerLValue) {


### PR DESCRIPTION
This small changes add information for `extract` operator then current header is a part of header union stack like in example from this [PR](https://github.com/p4lang/p4c/pull/3193). 
For example:
```
header O1 {
    bit<8> data;
}

header O2 {
    bit<16> data;
}

header_union U {
    O1 byte;
    O2 short;
}

struct headers {
    S    base;
    U[2] u;
}
....
parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
    state start {
        packet.extract(hdr.u.next.byte);
```